### PR TITLE
Tags can be used as part of the published name

### DIFF
--- a/examples/tasks/task.json
+++ b/examples/tasks/task.json
@@ -1,0 +1,40 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/foo": {},
+                "/intel/mock/bar": {},
+                "/intel/mock/*/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": [
+                {
+                    "plugin_name": "passthru",
+                    "process": null,
+                    "publish": [
+                        {
+                            "plugin_name": "graphite",
+                            "config": {
+                                "server": "127.0.0.1",
+                                "log-level": "debug",
+                                "prefix": "metrics",
+                                "prefix_tags": "plugin_running_on",
+                                "port": 2003
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -23,8 +23,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-
-	log "github.com/Sirupsen/logrus"
+	"strings"
 
 	plh "github.com/intelsdi-x/snap-plugin-publisher-graphite/logHelper"
 	"github.com/intelsdi-x/snap/control/plugin"
@@ -51,6 +50,7 @@ func (f *graphitePublisher) Publish(contentType string, content []byte, config m
 	logger := plh.GetLogger(config, Meta())
 	logger.Debug("Publishing started")
 	var metrics []plugin.MetricType
+	var tagsForPrefix []string
 
 	switch contentType {
 	case plugin.SnapGOBContentType:
@@ -68,6 +68,12 @@ func (f *graphitePublisher) Publish(contentType string, content []byte, config m
 
 	server := config["server"].(ctypes.ConfigValueStr).Value
 	port := config["port"].(ctypes.ConfigValueInt).Value
+
+	tagsConfig, ok := config["prefix_tags"]
+	if ok {
+		tagsForPrefix = strings.Split(tagsConfig.(ctypes.ConfigValueStr).Value, ",")
+	}
+
 	logger.Debug("Attempting to connect to %s:%d", server, port)
 	var gite *graphite.Graphite
 	var err error
@@ -76,22 +82,32 @@ func (f *graphitePublisher) Publish(contentType string, content []byte, config m
 	} else {
 		gite, err = graphite.NewGraphite(server, port)
 	}
+	defer gite.Disconnect()
 	if err != nil {
 		logger.Errorf("Error Connecting to graphite at %s:%d. Error: %v", server, port, err)
 		return fmt.Errorf("Error Connecting to graphite at %s:%d. Error: %v", server, port, err)
 	}
 	logger.Debug("Connected to %s:%s successfully", server, port)
-	for _, m := range metrics {
+	giteMetrics := make([]graphite.Metric, len(metrics))
+	for i, m := range metrics {
 		key := m.Namespace().Key()
-		data := fmt.Sprintf("%v", m.Data())
-		logger.Debug("Attempting to send %s:%s", key, data)
-		err = gite.SimpleSend(key, data)
-		if err != nil {
-			logger.Errorf("Unable to send metric %s:%s to %s:%d. Error: %s", key, data, server, port, err)
-			return fmt.Errorf("Unable to send metric %s:%s to %s:%d. Error: %s", key, data, server, port, err)
+		for _, tag := range tagsForPrefix {
+			nextTag, ok := m.Tags()[tag]
+			if ok {
+				key = nextTag + "." + key
+			}
 		}
-		logger.Debug("Sent %s, %s", key, data)
+		data := fmt.Sprintf("%v", m.Data())
+		logger.Debug("Metric ready to send %s:%s", key, data)
+		giteMetrics[i] = graphite.NewMetric(key, data, m.Timestamp().Unix())
 	}
+
+	err = gite.SendMetrics(giteMetrics)
+	if err != nil {
+		logger.Errorf("Unable to send metrics. Error: %s", err)
+		return fmt.Errorf("Unable to send metrics. Error: %s", err)
+	}
+	logger.Debug("Metrics sent to Graphite.")
 	return nil
 }
 
@@ -107,28 +123,27 @@ func (f *graphitePublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 		config = cpolicy.NewPolicyNode()
 	}
 	r1, err := cpolicy.NewStringRule("server", true)
-	handleErr(err)
+	if err != nil {
+		return nil, err
+	}
 	r1.Description = "Address of graphite server"
 	config.Add(r1)
 
 	r2, err := cpolicy.NewIntegerRule("port", true)
-	handleErr(err)
+	if err != nil {
+		return nil, err
+	}
 	r2.Description = "Port to connect on"
 	config.Add(r2)
 
 	r3, err := cpolicy.NewStringRule("prefix", false)
-	handleErr(err)
+	if err != nil {
+		return nil, err
+	}
 	r3.Description = "Prefix to add to all metrics"
 	config.Add(r3)
 
 	cp.Add([]string{""}, config)
 	fmt.Println(config)
 	return cp, nil
-}
-
-func handleErr(e error) {
-	if e != nil {
-		log.Panic(e)
-		panic(e)
-	}
 }


### PR DESCRIPTION
Fixes #7 & #8, add the ability to use tag values as part of the published series name.

Summary of changes:
- We can now specify a coma separated list of tags in the config of the sub_prefix we want to use.
- The published series name will be `<prefix>.<prefix_from_tags>.<namespace>`.
- Clean up some code.

How to verify it:
- Run the example task (see `examples/tasks/task.json`).

Testing done:
- `make test-small`.
- `make test-medium`.

A picture of a ~~snapping~~ graphite turtle (not required but encouraged):
![](http://orig08.deviantart.net/df76/f/2013/083/d/8/graphite_turtle_by_fireflyalpha-d5z50h2.jpg)
