### PR TITLE
POC: simplify plugin files structure

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,50 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+)
+
+func getLogger(cfg plugin.Config) *log.Entry {
+	logger := log.WithFields(log.Fields{
+		"plugin-name":    Name,
+		"plugin-version": Version,
+		"plugin-type":    "publisher",
+	})
+
+	log.SetLevel(log.WarnLevel)
+
+	levelValue, err := cfg.GetString("log-level")
+	if err == nil {
+		if level, err := log.ParseLevel(strings.ToLower(levelValue)); err == nil {
+			log.SetLevel(level)
+		} else {
+			log.WithFields(log.Fields{
+				"value":             strings.ToLower(levelValue),
+				"acceptable values": "warn, error, debug, info",
+			}).Warn("Invalid config value")
+		}
+	}
+	return logger
+}

--- a/main.go
+++ b/main.go
@@ -19,11 +19,13 @@ limitations under the License.
 
 package main
 
-import (
-	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
-	"github.com/intelsdi-x/snap-plugin-publisher-graphite/graphite"
+import "github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+
+const (
+	Name    = "graphite"
+	Version = 4
 )
 
 func main() {
-	plugin.StartPublisher(&graphite.GraphitePublisher{}, graphite.Name, graphite.Version)
+	plugin.StartPublisher(&GraphitePublisher{}, Name, Version)
 }

--- a/publisher.go
+++ b/publisher.go
@@ -17,20 +17,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package graphite
+package main
 
 import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 	"github.com/marpaia/graphite-golang"
-)
-
-const (
-	Name    = "graphite"
-	Version = 4
 )
 
 type GraphitePublisher struct {
@@ -102,27 +96,4 @@ func (f *GraphitePublisher) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy.AddNewStringRule([]string{""}, "log-level", false)
 
 	return *policy, nil
-}
-
-func getLogger(cfg plugin.Config) *log.Entry {
-	logger := log.WithFields(log.Fields{
-		"plugin-name":    Name,
-		"plugin-version": Version,
-		"plugin-type":    "publisher",
-	})
-
-	log.SetLevel(log.WarnLevel)
-
-	levelValue, err := cfg.GetString("log-level")
-	if err == nil {
-		if level, err := log.ParseLevel(strings.ToLower(levelValue)); err == nil {
-			log.SetLevel(level)
-		} else {
-			log.WithFields(log.Fields{
-				"value":             strings.ToLower(levelValue),
-				"acceptable values": "warn, error, debug, info",
-			}).Warn("Invalid config value")
-		}
-	}
-	return logger
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package graphite
+package main
 
 import (
 	"testing"


### PR DESCRIPTION
Plugin methods are moved to the main package instead of a subpackage.