### PR TITLE
Fixes #30, changed task manifest

### DIFF
--- a/examples/tasks/mock-passthru-graphite.json
+++ b/examples/tasks/mock-passthru-graphite.json
@@ -7,9 +7,7 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/mock/foo": {},
-                "/intel/mock/bar": {},
-                "/intel/mock/*/baz": {}
+                "/intel/mock/*": {}
             },
             "config": {
                 "/intel/mock": {


### PR DESCRIPTION
Summary of changes:
-  changed task manifest which is used in large tests

Now snap-plugin-collector-mock2-grpc plugin exposes the following metrics:
```
$ snaptel metric list
NAMESPACE 			 VERSIONS
/intel/mock/*/baz㊽/|barᵹÄ☍ 	 1
|intel|mock|*|/baz⽔ 		 1
|intel|mock|*|baz㊽|/bar⽔ 	 1
|intel|mock|/bar⽔ 		 1
|intel|mock|/foo=㊽ 		 1
```
so creating the task manifest to collect these metrics:
```
"/intel/mock/foo": {},
"/intel/mock/bar": {},
"/intel/mock/*/baz": {}
```
causes this error:
```
Error creating task:Metric not found: /intel/mock/*/baz (version: 0)
Metric not found: /intel/mock/bar (version: 0)
Metric not found: /intel/mock/foo (version: 0)
```

How to verify it:
- large tests are running without errors

