### PR TITLE
remvoe Sirupsen logrus path in glide.lock

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -20,8 +20,6 @@ imports:
   version: c474c9b821b4d0a4574edc6412b0003fbce233c4
 - name: github.com/sirupsen/logrus
   version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
-- name: github.com/Sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/crypto


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes # sirupsen/logrus#570 (comment)

Summary of changes:
- update import path of sirupsen logrus

Testing done:
- make test-small done
