### PR TITLE
add tag functionality for updated carbon tag format

### DIFF
--- a/examples/tasks/psutil-graphite-tags-enabled.yml
+++ b/examples/tasks/psutil-graphite-tags-enabled.yml
@@ -1,0 +1,23 @@
+---
+version: 1
+schedule:
+  type: simple
+  interval: 1s 
+# NOTE: fail fast for testing, not typical setting
+max-failures: 1
+workflow:
+  collect:
+    metrics:
+      "/intel/psutil/load/load1": {}
+      "/intel/psutil/load/load15": {}
+      "/intel/psutil/load/load5": {}
+      "/intel/psutil/vm/available": {}
+      "/intel/psutil/vm/free": {}
+      "/intel/psutil/vm/used": {}
+      "/intel/psutil/cpu/*/user": {}
+    publish:
+    - plugin_name: graphite
+      config:
+        server: graphite
+        port: 2003
+        enable_tags: true

--- a/graphite/graphite_medium_test.go
+++ b/graphite/graphite_medium_test.go
@@ -54,6 +54,7 @@ func TestGraphitePublisher(t *testing.T) {
 		"port":        int64(80),
 		"prefix":      "medium_test_prefix",
 		"prefix_tags": "medium_test_prefix_tag_1,medium_test_prefix_tag_2",
+		"enable_tags": true,
 	}
 	tags := map[string]string{"zone": "red"}
 	mcfg := map[string]interface{}{"field": "abc123"}
@@ -108,6 +109,7 @@ func TestWrongConfig(t *testing.T) {
 	config := plugin.Config{
 		"prefix":      "medium_test_prefix",
 		"prefix_tags": "medium_test_prefix_tag_1,medium_test_prefix_tag_2",
+		"enable_tags": false,
 	}
 	Convey("Incorrect config ", t, func() {
 		Convey("nil server and port", func() {


### PR DESCRIPTION
Summary of changes:
- Add a enable_tag feature that converts dynamic namespaces and snap tags into the new carbon tagging format

Testing done:
- Ran plugin locally
- Added new test cases for generating graphite name strings
